### PR TITLE
Stop event propagation when writing comment

### DIFF
--- a/frontend/src/components/form/InputTextarea.vue
+++ b/frontend/src/components/form/InputTextarea.vue
@@ -28,6 +28,7 @@ function updateValue(e: any) {
       class="border-smoke font-14"
       :type="type"
       @input="updateValue"
+      @keydown="(e) => e.stopPropagation()"
       :value="value"
     />
     <div class="input-error-list" v-if="error && error.invalid">


### PR DESCRIPTION
This stops any events from leaving the textarea and it won't trigger image change when arrow keys are pressed.

Resolves #39 