### PR TITLE
Disable rendering of background color on images by default

### DIFF
--- a/frontend/src/style/generic/_error.scss
+++ b/frontend/src/style/generic/_error.scss
@@ -17,5 +17,9 @@ img {
         background-image: url("/user.svg");
       }
     }
+
+    &:not(.image-error) {
+      background-color: transparent !important;
+    }
   }
 }


### PR DESCRIPTION
This fixes issue of a tiny gap of color leaking at the edge of every image. It is cause by setting a background-color to and <img> tag which also has a source picture.

I think it is a CSS bug