### PR TITLE
Add activity log endpoint

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -36,9 +36,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
+checksum = "c91f1f46651137be86f3a2b9a8359f9ab421d04d941c62b5982e1ca21113adf9"
 
 [[package]]
 name = "argh"
@@ -88,9 +88,9 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-trait"
-version = "0.1.56"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96cf8829f67d2eab0b2dfa42c5d0ef737e0724e4a82b01b3e292456202b19716"
+checksum = "76464446b8bc32758d7e88ee1a804d9914cd9b1cb264c029899680b0be29826f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -105,9 +105,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.5.11"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2cc6e8e8c993cb61a005fab8c1e5093a29199b7253b05a6883999312935c1ff"
+checksum = "6b9496f0c1d1afb7a2af4338bbe1d969cddfead41d87a9fb3aaa6d0bbc7af648"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -138,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4d047478b986f14a13edad31a009e2e05cb241f9805d0d75e4cba4e129ad4d"
+checksum = "e4f44a0e6200e9d11a1cdc989e4b358f6e3d354fbf48478f345a17f4e43f8635"
 dependencies = [
  "async-trait",
  "bytes",
@@ -227,9 +227,9 @@ checksum = "37ccbd214614c6783386c1af30caf03192f17891059cecc394b4fb119e363de3"
 
 [[package]]
 name = "bytemuck"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c53dfa917ec274df8ed3c572698f381a24eef2efba9492d797301b72b6db408a"
+checksum = "a5377c8865e74a160d21f29c2d40669f53286db6eab59b88540cbb12ffc8b835"
 
 [[package]]
 name = "byteorder"
@@ -239,9 +239,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
 name = "cc"
@@ -254,6 +254,19 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "serde",
+ "winapi",
+]
 
 [[package]]
 name = "color_quant"
@@ -297,9 +310,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.5"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c02a4d71819009c192cf4872265391563fd6a84c81ff2c0f2a7026ca4c1d85c"
+checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -307,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
 dependencies = [
  "cfg-if",
  "crossbeam-epoch",
@@ -318,9 +331,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07db9d94cbd326813772c968ccd25999e5f8ae22f4f8d1b11effa37ef6ce281d"
+checksum = "045ebe27666471bb549370b4b0b3e51b07f56325befa4284db65fc89c02511b1"
 dependencies = [
  "autocfg",
  "cfg-if",
@@ -332,9 +345,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d82ee10ce34d7bc12c2122495e7593a9c41347ecdd64185af4ecf72cb1a7f83"
+checksum = "51887d4adc7b564537b15adcfb307936f8075dfcd5f00dde9a9f1d29383682bc"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -342,12 +355,47 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.1.4"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5999502d32b9c48d492abe66392408144895020ec4709e549e840799f3bb74c0"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -421,9 +469,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
 ]
@@ -440,9 +488,9 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.10.13"
+version = "0.10.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ceeb589a3157cac0ab8cc585feb749bd2cea5cb55a6ee802ad72d9fd38303da"
+checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -529,9 +577,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.5"
+version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd48d33ec7f05fbfa152300fdad764757cbded343c1aa1cff2fbaf4134851803"
+checksum = "bff49e947297f3312447abdca79f45f4738097cc82b06e72054d2223f601f1b9"
 dependencies = [
  "typenum",
  "version_check",
@@ -596,9 +644,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db0d4cf898abf0081f964436dc980e96670a0f36863e4b83aaacdb65c9d7ccc3"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashlink"
@@ -653,6 +701,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hivefriends"
 version = "0.1.0"
 dependencies = [
@@ -678,6 +732,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_rusqlite",
+ "serde_with",
  "tempdir",
  "test-case",
  "thiserror",
@@ -731,9 +786,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.19"
+version = "0.14.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42dc3c131584288d375f2d07f822b0cb012d8c6fb899a5b9fdb3cb7eb9b6004f"
+checksum = "02c929dc5c39e335a03c405292728118860721b10190d98c2a0f0efd5baafbac"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -767,6 +822,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -779,9 +840,9 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.24.2"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28edd9d7bc256be2502e325ac0628bde30b7001b9b52e0abe31a1a9dc2701212"
+checksum = "7e30ca2ecf7666107ff827a8e481de6a132a9b687ed3bb20bb1c144a36c00964"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -789,7 +850,6 @@ dependencies = [
  "exr",
  "gif",
  "jpeg-decoder",
- "num-iter",
  "num-rational",
  "num-traits",
  "png",
@@ -804,7 +864,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
- "hashbrown 0.12.1",
+ "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -842,9 +903,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "jpeg-decoder"
@@ -857,9 +918,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.58"
+version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3fac17f7123a73ca62df411b1bf727ccc805daa070338fda671c86dac1bdc27"
+checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -996,9 +1057,9 @@ dependencies = [
 
 [[package]]
 name = "multer"
-version = "2.0.2"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f8f35e687561d5c1667590911e6698a8cb714a134a7505718a182e7bc9d3836"
+checksum = "a30ba6d97eb198c5e8a35d67d5779d6680cca35652a60ee90fc23dc431d4fde8"
 dependencies = [
  "bytes",
  "encoding_rs",
@@ -1056,17 +1117,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-iter"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-rational"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1107,15 +1157,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709cef83f0c1f58f666e746a08b21e0085f7440fa6a29cc194d68aac97a4225"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "openssl"
-version = "0.10.40"
+version = "0.10.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb81a6430ac911acb25fe5ac8f1d2af1b4ea8a4fdfda0f1ee4292af2e2d8eb0e"
+checksum = "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1145,9 +1195,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.74"
+version = "0.9.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835363342df5fba8354c5b453325b110ffd54044e588c539cf2f20a8014e4cb1"
+checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
 dependencies = [
  "autocfg",
  "cc",
@@ -1255,18 +1305,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.40"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96a1e8ed2596c337f8eae5f24924ec83f5ad5ab21ea8e455d3566c69fbcaf7"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
@@ -1364,18 +1414,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.13"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.5.6"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
+checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
  "regex-syntax",
 ]
@@ -1391,9 +1441,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.26"
+version = "0.6.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+checksum = "a3f87b73ce11b1619a3c6332f45341e0047173771e8b8b73f87bfeefb7b56244"
 
 [[package]]
 name = "remove_dir_all"
@@ -1481,9 +1531,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "schannel"
@@ -1532,18 +1582,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.138"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1578c6245786b9d168c5447eeacfb96856573ca56c9d68fdcf394be134882a47"
+checksum = "e590c437916fb6b221e1d00df6e3294f3fccd70ca7e92541c475d6ed6ef5fee2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.138"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "023e9b1467aef8a10fb88f25611870ada9800ef7e22afce356bb0d2387b6f27c"
+checksum = "34b5b8d809babe02f538c2cfec6f2c1ed10804c0e5a6a041a049a4f5588ccc2e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1552,9 +1602,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.82"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82c2c1fdcd807d1098552c5b9a36e425e42e9fbd7c6a37a8425f390f781f7fa7"
+checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
 dependencies = [
  "itoa",
  "ryu",
@@ -1584,6 +1634,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89df7a26519371a3cce44fbb914c2819c84d9b897890987fa3ab096491cc0ea8"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap",
+ "serde",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de337f322382fcdfbb21a014f7c224ee041a23785651db67b9827403178f698f"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1605,9 +1683,12 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
+checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "smallvec"
@@ -1627,12 +1708,18 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c530c2b0d0bf8b69304b39fe2001993e267461948b890cd037d8ad4293fa1a0d"
+checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
 dependencies = [
  "lock_api",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"
@@ -1642,9 +1729,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.98"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
+checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1683,18 +1770,18 @@ dependencies = [
 
 [[package]]
 name = "test-case"
-version = "2.1.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "196e8a70562e252cc51eaaaee3ecddc39803d9b7fd4a772b7c7dae7cdf42a859"
+checksum = "07aea929e9488998b64adc414c29fe5620398f01c2e3f58164122b17e567a6d5"
 dependencies = [
  "test-case-macros",
 ]
 
 [[package]]
 name = "test-case-macros"
-version = "2.1.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dd461f47ade621665c9f4e44b20449341769911c253275dc5cb03726cbb852c"
+checksum = "c95968eedc6fc4f5c21920e0f4264f78ec5e4c56bb394f319becc1a5830b3e54"
 dependencies = [
  "cfg-if",
  "proc-macro-error",
@@ -1705,18 +1792,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.31"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.31"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1743,9 +1830,9 @@ dependencies = [
 
 [[package]]
 name = "tiff"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cfada0986f446a770eca461e8c6566cb879682f7d687c8348aa0c857bd52286"
+checksum = "7259662e32d1e219321eb309d5f9d898b779769d81b76e762c07c8e5d38fcb65"
 dependencies = [
  "flate2",
  "jpeg-decoder",
@@ -1754,12 +1841,15 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.11"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c91f41dcb2f096c05f0873d667dceec1087ce5bcf984ec8ffb19acddbb3217"
+checksum = "74b7cc93fc23ba97fde84f7eea56c55d1ba183f495c6715defdfc7b9cb8c870f"
 dependencies = [
+ "itoa",
+ "js-sys",
  "libc",
  "num_threads",
+ "serde",
 ]
 
 [[package]]
@@ -1779,10 +1869,11 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.19.2"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51a52ed6686dd62c320f9b89299e9dfb46f730c7a48e635c19f21d116cb1439"
+checksum = "7a8325f63a7d4774dd041e363b2409ed1c5cbbd0f867795e661df066b2b0a581"
 dependencies = [
+ "autocfg",
  "bytes",
  "libc",
  "memchr",
@@ -1818,8 +1909,8 @@ dependencies = [
 
 [[package]]
 name = "tokio-rusqlite"
-version = "0.1.0"
-source = "git+https://github.com/programatik29/tokio-rusqlite#9d1302256e0df8d7d1f738e48ebd1b3ce16dd928"
+version = "0.2.0"
+source = "git+https://github.com/programatik29/tokio-rusqlite#ea696510ad6e5930590f8dcf65cd244eb1a83974"
 dependencies = [
  "crossbeam-channel",
  "rusqlite",
@@ -1896,9 +1987,9 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.35"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
+checksum = "2fce9567bd60a67d08a16488756721ba392f24f29006402881e43b19aac64307"
 dependencies = [
  "cfg-if",
  "log",
@@ -1920,9 +2011,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
+checksum = "5aeea4303076558a00714b823f9ad67d58a3bbda1df83d8827d21193156e22f7"
 dependencies = [
  "once_cell",
  "valuable",
@@ -1941,9 +2032,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.14"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a713421342a5a666b7577783721d3117f1b69a393df803ee17bb73b1e122a59"
+checksum = "60db860322da191b40952ad9affe65ea23e7dd6a5c442c2c42865810c6ab8e6b"
 dependencies = [
  "ansi_term",
  "matchers",
@@ -1986,9 +2077,9 @@ checksum = "099b7128301d285f79ddd55b9a83d5e6b9e97c92e0ea0daebee7263e932de992"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bd2fe26506023ed7b5e1e315add59d6f584c621d037f9368fea9cfb988f368c"
+checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
 
 [[package]]
 name = "unicode-normalization"
@@ -2062,9 +2153,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c53b543413a17a202f4be280a7e5c62a1c69345f5de525ee64f8cfdbc954994"
+checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -2072,13 +2163,13 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5491a68ab4500fa6b4d726bd67408630c3dbe9c4fe7bda16d5c82a1fd8c7340a"
+checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -2087,9 +2178,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de9a9cec1733468a8c657e57fa2413d2ae2c0129b95e87c5b72b8ace4d13f31f"
+checksum = "fa76fb221a1f8acddf5b54ace85912606980ad661ac7a503b4570ffd3a624dad"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2099,9 +2190,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c441e177922bc58f1e12c022624b6216378e5febc2f0533e41ba443d505b80aa"
+checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2109,9 +2200,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d94ac45fcf608c1f45ef53e748d35660f168490c10b23704c7779ab8f5c3048"
+checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2122,15 +2213,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a89911bd99e5f3659ec4acf9c4d93b0a90fe4a2a11f15328472058edc5261be"
+checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
 
 [[package]]
 name = "web-sys"
-version = "0.3.58"
+version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fed94beee57daf8dd7d51f2b15dc2bcde92d7a72304cdf662a4371008b71b90"
+checksum = "ed055ab27f941423197eb86b2035720b1a3ce40504df082cac2ecc6ed73335a1"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2138,9 +2229,9 @@ dependencies = [
 
 [[package]]
 name = "weezl"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c97e489d8f836838d497091de568cf16b117486d529ec5579233521065bd5e4"
+checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
 
 [[package]]
 name = "winapi"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -30,6 +30,7 @@ kamadak-exif = "0.5.4"
 async-trait = "0.1.56"
 itertools = "0.10.3"
 time = { version = "0.3.11", features = ["parsing"] }
+serde_with = "2.0.0"
 
 [dependencies.rusqlite_migration]
 git = "https://github.com/cljoly/rusqlite_migration"

--- a/backend/migrations/002_username_collate_nocase.sql
+++ b/backend/migrations/002_username_collate_nocase.sql
@@ -46,7 +46,7 @@ SELECT
     i.f_number,
     i.focal_length,
     i.description,
-    (SELECT u.username FROM users u where u.username = i.uploader) as uploader,
+    (SELECT u.username FROM users u WHERE u.username = i.uploader) AS uploader,
     i.uploaded_at
 FROM images i;
 
@@ -84,7 +84,7 @@ CREATE TABLE comments_new (
 INSERT OR REPLACE INTO comments_new
 SELECT
     c.id,
-    (SELECT u.username FROM users u where u.username = c.author) as author,
+    (SELECT u.username FROM users u WHERE u.username = c.author) AS author,
     c.album_key,
     c.image_key,
     c.created_at,
@@ -127,7 +127,7 @@ SELECT
     a.title,
     a.description,
     a.cover_key,
-    (SELECT u.username FROM users u where u.username = a.author) as author,
+    (SELECT u.username FROM users u WHERE u.username = a.author) AS author,
     a.draft,
     a.timeframe_from,
     a.timeframe_to,
@@ -155,7 +155,7 @@ CREATE TABLE auth_sessions_new (
 INSERT OR REPLACE INTO auth_sessions_new
 SELECT
     s.id,
-    (SELECT u.username FROM users u where u.username = s.username),
+    (SELECT u.username FROM users u WHERE u.username = s.username),
     s.token,
     s.created_at
 FROM auth_sessions s;
@@ -186,7 +186,7 @@ CREATE TABLE user_album_associations_new (
 
 INSERT OR REPLACE INTO user_album_associations_new
 SELECT
-    (SELECT u.username FROM users u where u.username = uaa.username),
+    (SELECT u.username FROM users u WHERE u.username = uaa.username),
     uaa.album_key
 FROM user_album_associations uaa;
 
@@ -217,7 +217,7 @@ INSERT OR REPLACE INTO album_share_tokens_new
 SELECT
     ast.share_token,
     ast.album_key,
-    (SELECT u.username FROM users u where u.username = ast.created_by),
+    (SELECT u.username FROM users u WHERE u.username = ast.created_by),
     ast.created_at
 FROM album_share_tokens ast;
 

--- a/backend/migrations/003_activity_changes.sql
+++ b/backend/migrations/003_activity_changes.sql
@@ -1,0 +1,39 @@
+ -- this value gets updated when draft is unset on the album
+ALTER TABLE albums
+RENAME COLUMN created_at TO published_at;
+
+CREATE TABLE album_image_associations_new (
+    image_key TEXT NOT NULL, -- image is a part of:
+    album_key TEXT NOT NULL, -- this album
+    idx INTEGER NOT NULL, -- position in the album
+    created_at INTEGER NOT NULL, -- unix ts
+
+    UNIQUE(image_key, album_key, idx),
+    CONSTRAINT fk_image_key_assoc
+        FOREIGN KEY (image_key)
+        REFERENCES images (key)
+        ON DELETE CASCADE,
+
+    CONSTRAINT fk_album_key_assoc
+        FOREIGN KEY (album_key)
+        REFERENCES albums (key)
+        ON DELETE CASCADE
+) STRICT;
+
+INSERT OR REPLACE INTO album_image_associations_new
+SELECT
+    aia.image_key,
+    aia.album_key,
+    aia.idx,
+    (
+        SELECT i.uploaded_at
+        FROM images i
+        JOIN album_image_associations aia2 ON aia2.image_key = i.key
+        WHERE aia2.image_key = aia.image_key
+        AND aia2.album_key = aia.album_key
+    ) as created_at
+FROM album_image_associations aia;
+
+DROP TABLE album_image_associations;
+
+ALTER TABLE album_image_associations_new RENAME TO album_image_associations;

--- a/backend/src/api/activity.rs
+++ b/backend/src/api/activity.rs
@@ -1,0 +1,239 @@
+use anyhow::Context;
+use axum::{routing::get, Router};
+use axum::{Extension, Json};
+use rusqlite::{params, Connection};
+use serde::Serialize;
+use serde_rusqlite::from_row;
+
+use crate::api::error::Error;
+use crate::api::{
+    album::AlbumMetadata,
+    comment::Comment,
+    image::{DbImage, Image},
+    user::{self, User},
+};
+use crate::AppState;
+
+use super::album::{self, AlbumFilters};
+use super::auth::Authorize;
+use super::comment;
+use std::sync::Arc;
+
+use serde_with::skip_serializing_none;
+
+pub fn api_route() -> Router {
+    Router::new().route("/", get(get_activities))
+}
+
+#[skip_serializing_none]
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+enum Activity {
+    Album(AlbumMetadata),
+    Comment(Comment),
+    User(User),
+    Image(Image),
+}
+
+pub fn get_new_images(conn: &Connection) -> Result<Vec<Image>, Error> {
+    let mut query = conn
+        .prepare(
+            "SELECT i.*, aia.created_at as published_at FROM images i \
+            INNER JOIN album_image_associations aia ON i.key = aia.image_key \
+            INNER JOIN albums a ON a.key = aia.album_key \
+            WHERE a.published_at < aia.created_at",
+        )
+        .context("Failed to prepare statement for images query")?;
+
+    let images = query
+        .query_map(params![], |row| {
+            Ok(Image::from_db(from_row::<DbImage>(row).unwrap()))
+        })
+        .context("Failed to query user images")?
+        .collect::<Result<Vec<_>, _>>()
+        .context("Failed to collect user images")?;
+
+    Ok(images)
+}
+
+async fn get_activities(
+    Authorize(username): Authorize,
+    Extension(state): Extension<Arc<AppState>>,
+) -> Result<Json<Vec<Activity>>, Error> {
+    state
+        .db
+        .call(move |conn| {
+            let filters = AlbumFilters {
+                draft: false,
+                ..Default::default()
+            };
+            let albums = album::get_all::get_albums(username, filters, conn)?
+                .into_iter()
+                .map(Activity::Album);
+
+            let users = user::get_all(conn)?
+                .into_iter()
+                .map(Activity::User);
+
+            let comments = comment::get_all(conn)?
+                .into_iter()
+                .map(Activity::Comment);
+
+            let images = get_new_images(conn)?
+                .into_iter()
+                .map(Activity::Image);
+
+            let mut activities: Vec<Activity> =
+                albums.chain(users).chain(comments).chain(images).collect();
+
+            activities.sort_unstable_by(|a, b| b.cmp(a));
+
+            Ok(Json(activities))
+        })
+        .await
+}
+
+// Activities should not contain images without publish date since those images are private.
+impl PartialEq for Activity {
+    fn eq(&self, other: &Activity) -> bool {
+        use Activity::*;
+
+        let this_time = match self {
+            Album(a) => a.published_at,
+            Comment(c) => c.created_at,
+            User(u) => u.created_at,
+            Image(i) => i.published_at.unwrap(),
+        };
+
+        let other_time = match other {
+            Album(a) => a.published_at,
+            Comment(c) => c.created_at,
+            User(u) => u.created_at,
+            Image(i) => i.published_at.unwrap(),
+        };
+
+        this_time == other_time
+    }
+}
+
+impl PartialOrd for Activity {
+    fn partial_cmp(&self, other: &Activity) -> Option<std::cmp::Ordering> {
+        use Activity::*;
+
+        let this_time = match self {
+            Album(a) => a.published_at,
+            Comment(c) => c.created_at,
+            User(u) => u.created_at,
+            Image(i) => i.published_at.unwrap(),
+        };
+
+        let other_time = match other {
+            Album(a) => a.published_at,
+            Comment(c) => c.created_at,
+            User(u) => u.created_at,
+            Image(i) => i.published_at.unwrap(),
+        };
+
+        this_time.partial_cmp(&other_time)
+    }
+}
+
+impl Eq for Activity {}
+
+impl Ord for Activity {
+    fn cmp(&self, other: &Activity) -> std::cmp::Ordering {
+        self.partial_cmp(other).unwrap()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::api::album::InsertAlbum;
+    use crate::api::image;
+    use crate::util::test::{insert_album, insert_image, insert_user};
+    use assert_matches::assert_matches;
+    use axum::extract::Path;
+
+    #[tokio::test]
+    async fn get_activity() {
+        let state = AppState::in_memory_db().await;
+
+        let (expected_user, expected_album, expected_image, expected_comment) = state
+            .db
+            .call(move |conn| {
+                let user = insert_user("test", conn);
+                let image = insert_image(&user, conn);
+                let album = insert_album(
+                    InsertAlbum {
+                        cover_key: &image,
+                        image_keys: &[image.clone()],
+                        author: &user,
+                        published_at: 1,
+                        ..Default::default()
+                    },
+                    conn,
+                );
+
+                let new_image_key = blob_uuid::random_blob();
+
+                image::insert(
+                    &DbImage {
+                        key: new_image_key.clone(),
+                        uploader: user.clone(),
+                        uploaded_at: 2,
+
+                        ..Default::default()
+                    },
+                    conn,
+                )
+                .unwrap();
+
+                let comment = comment::insert_comment(
+                    user.clone(),
+                    String::from("foo"),
+                    image,
+                    album.clone(),
+                    3,
+                    conn,
+                )
+                .unwrap();
+
+                (user, album, new_image_key, comment)
+            })
+            .await;
+
+        let request = album::update::PutAlbumRequest {
+            image_keys: Some(vec![expected_image.clone()]),
+            ..Default::default()
+        };
+        album::update::put(
+            Ok(Json(request)),
+            Path(expected_album.clone()),
+            Authorize(expected_user.clone()),
+            Extension(state.clone()),
+        ).await.unwrap();
+
+        let result = get_activities(Authorize("".into()), Extension(state)).await;
+
+        dbg!(&result);
+        assert_matches!(result, Ok(Json(activities)) => {
+            assert_matches!(&activities[0], Activity::Image(image) => {
+                assert_eq!(expected_image, image.key);
+            });
+
+            assert_matches!(&activities[1], Activity::Comment(comment) => {
+                assert_eq!(expected_comment.text, comment.text);
+            });
+
+            assert_matches!(&activities[2], Activity::Album(album) => {
+                assert_eq!(expected_album, album.key);
+            });
+
+            assert_matches!(&activities[3], Activity::User(user) => {
+                assert_eq!(expected_user, user.username);
+            });
+
+        });
+    }
+}

--- a/backend/src/api/album/create.rs
+++ b/backend/src/api/album/create.rs
@@ -79,7 +79,7 @@ pub(super) async fn post(
                     draft: request.draft,
                     timeframe_from: request.timeframe.from,
                     timeframe_to: request.timeframe.to,
-                    created_at: now,
+                    published_at: now,
                     image_keys: &request.image_keys,
                     tagged_users: &request.tagged_users,
                 },
@@ -108,12 +108,12 @@ mod test {
         let (user_a, user_b, images) = state
             .db
             .call(move |conn| {
-                let user_a = insert_user("test", conn).unwrap();
-                let user_b = insert_user("test2", conn).unwrap();
+                let user_a = insert_user("test", conn);
+                let user_b = insert_user("test2", conn);
                 let images = vec![
-                    insert_image(&user_a, conn).unwrap(),
-                    insert_image(&user_a, conn).unwrap(),
-                    insert_image(&user_a, conn).unwrap(),
+                    insert_image(&user_a, conn),
+                    insert_image(&user_a, conn),
+                    insert_image(&user_a, conn),
                 ];
 
                 (user_a, user_b, images)
@@ -142,10 +142,7 @@ mod test {
     async fn create_album_cover_key_not_in_image_keys() {
         let state = AppState::in_memory_db().await;
 
-        let user = state
-            .db
-            .call(move |conn| insert_user("test", conn).unwrap())
-            .await;
+        let user = state.db.call(move |conn| insert_user("test", conn)).await;
 
         let request = CreateAlbumRequest {
             title: "album".into(),
@@ -165,8 +162,8 @@ mod test {
         let (user, image) = state
             .db
             .call(move |conn| {
-                let user = insert_user("test", conn).unwrap();
-                let image = insert_image(&user, conn).unwrap();
+                let user = insert_user("test", conn);
+                let image = insert_image(&user, conn);
 
                 (user, image)
             })
@@ -192,8 +189,8 @@ mod test {
         let (user, image) = state
             .db
             .call(move |conn| {
-                let user = insert_user("test", conn).unwrap();
-                let image = insert_image(&user, conn).unwrap();
+                let user = insert_user("test", conn);
+                let image = insert_image(&user, conn);
 
                 (user, image)
             })

--- a/backend/src/api/album/create_share_token.rs
+++ b/backend/src/api/album/create_share_token.rs
@@ -64,8 +64,8 @@ mod test {
         let (user, album_key) = state
             .db
             .call(move |conn| {
-                let user = insert_user("test", conn).unwrap();
-                let image = insert_image(&user, conn).unwrap();
+                let user = insert_user("test", conn);
+                let image = insert_image(&user, conn);
                 let album_key = insert_album(
                     InsertAlbum {
                         cover_key: &image,
@@ -73,8 +73,7 @@ mod test {
                         ..Default::default()
                     },
                     conn,
-                )
-                .unwrap();
+                );
 
                 (user, album_key)
             })

--- a/backend/src/api/album/delete_album.rs
+++ b/backend/src/api/album/delete_album.rs
@@ -44,8 +44,8 @@ mod test {
         let user = state
             .db
             .call(move |conn| {
-                let user = insert_user("test", conn).unwrap();
-                let image = insert_image(&user, conn).unwrap();
+                let user = insert_user("test", conn);
+                let image = insert_image(&user, conn);
                 let _ = insert_album(
                     InsertAlbum {
                         cover_key: &image,
@@ -54,8 +54,7 @@ mod test {
                         ..Default::default()
                     },
                     conn,
-                )
-                .unwrap();
+                );
 
                 user
             })
@@ -73,8 +72,8 @@ mod test {
         let (user2, album) = state
             .db
             .call(move |conn| {
-                let user = insert_user("test", conn).unwrap();
-                let image = insert_image(&user, conn).unwrap();
+                let user = insert_user("test", conn);
+                let image = insert_image(&user, conn);
                 let album = insert_album(
                     InsertAlbum {
                         cover_key: &image,
@@ -83,9 +82,8 @@ mod test {
                         ..Default::default()
                     },
                     conn,
-                )
-                .unwrap();
-                let user2 = insert_user("test2", conn).unwrap();
+                );
+                let user2 = insert_user("test2", conn);
 
                 (user2, album)
             })
@@ -103,8 +101,8 @@ mod test {
         let (user, album) = state
             .db
             .call(move |conn| {
-                let user = insert_user("test", conn).unwrap();
-                let image = insert_image(&user, conn).unwrap();
+                let user = insert_user("test", conn);
+                let image = insert_image(&user, conn);
                 let album = insert_album(
                     InsertAlbum {
                         cover_key: &image,
@@ -113,8 +111,7 @@ mod test {
                         ..Default::default()
                     },
                     conn,
-                )
-                .unwrap();
+                );
 
                 (user, album)
             })

--- a/backend/src/api/album/get_all.rs
+++ b/backend/src/api/album/get_all.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use axum::{extract::Query, Extension, Json};
-use rusqlite::params;
+use rusqlite::{params, Connection};
 use serde_rusqlite::from_row;
 
 use std::sync::Arc;
@@ -10,15 +10,12 @@ use crate::AppState;
 
 use super::{apply_filters, AlbumFilters, AlbumMetadata, DbAlbum, Timeframe};
 
-pub(super) async fn get(
-    Authorize(username): Authorize,
-    Query(filter): Query<AlbumFilters>,
-    Extension(state): Extension<Arc<AppState>>,
-) -> Result<Json<Vec<AlbumMetadata>>, Error> {
-    state
-        .db
-        .call(move |conn| {
-            let mut query = "SELECT \
+pub fn get_albums(
+    username: String,
+    filter: AlbumFilters,
+    conn: &Connection,
+) -> Result<Vec<AlbumMetadata>, Error> {
+    let mut query = "SELECT \
                     key, \
                     title, \
                     description, \
@@ -27,60 +24,70 @@ pub(super) async fn get(
                     draft, \
                     timeframe_from, \
                     timeframe_to, \
-                    created_at \
+                    published_at \
                 FROM albums"
-                .to_string();
+        .to_string();
 
-            let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
+    let mut params: Vec<Box<dyn rusqlite::ToSql>> = Vec::new();
 
-            apply_filters(&mut query, &mut params, filter, username);
+    apply_filters(&mut query, &mut params, filter, username);
 
-            let mut stmt = conn
-                .prepare(&format!(
-                    "{query} \
+    let mut stmt = conn
+        .prepare(&format!(
+            "{query} \
                 ORDER BY \
-                    created_at DESC"
-                ))
-                .context("Failed to prepare statement for album query")?;
-            let db_albums = stmt
-                .query_map(rusqlite::params_from_iter(params.iter()), |row| {
-                    Ok(from_row::<DbAlbum>(row).unwrap())
-                })
-                .context("Failed to query albums")?
-                .collect::<Result<Vec<_>, _>>()
-                .context("Failed to collect albums")?;
-
-            let mut albums = Vec::new();
-            for db_album in db_albums {
-                let mut stmt = conn
-                    .prepare(
-                        "SELECT username FROM user_album_associations \
-                        WHERE album_key = ?1",
-                    )
-                    .context("Failed to prepare statement for album query")?;
-                let tagged_users = stmt
-                    .query_map(params![&db_album.key], |row| row.get(0))
-                    .context("Failed to query tagged users")?
-                    .collect::<Result<Vec<String>, _>>()
-                    .context("Failed to collect tagged users")?;
-
-                albums.push(AlbumMetadata {
-                    key: db_album.key,
-                    title: db_album.title,
-                    description: db_album.description,
-                    cover_key: db_album.cover_key,
-                    author: db_album.author,
-                    draft: db_album.draft,
-                    timeframe: Timeframe {
-                        from: db_album.timeframe_from,
-                        to: db_album.timeframe_to,
-                    },
-                    created_at: db_album.created_at,
-                    tagged_users,
-                })
-            }
-            Ok(Json(albums))
+                    published_at DESC"
+        ))
+        .context("Failed to prepare statement for album query")?;
+    let db_albums = stmt
+        .query_map(rusqlite::params_from_iter(params.iter()), |row| {
+            Ok(from_row::<DbAlbum>(row).unwrap())
         })
+        .context("Failed to query albums")?
+        .collect::<Result<Vec<_>, _>>()
+        .context("Failed to collect albums")?;
+
+    let mut albums = Vec::new();
+    for db_album in db_albums {
+        let mut stmt = conn
+            .prepare(
+                "SELECT username FROM user_album_associations \
+                        WHERE album_key = ?1",
+            )
+            .context("Failed to prepare statement for album query")?;
+        let tagged_users = stmt
+            .query_map(params![&db_album.key], |row| row.get(0))
+            .context("Failed to query tagged users")?
+            .collect::<Result<Vec<String>, _>>()
+            .context("Failed to collect tagged users")?;
+
+        albums.push(AlbumMetadata {
+            key: db_album.key,
+            title: db_album.title,
+            description: db_album.description,
+            cover_key: db_album.cover_key,
+            author: db_album.author,
+            draft: db_album.draft,
+            timeframe: Timeframe {
+                from: db_album.timeframe_from,
+                to: db_album.timeframe_to,
+            },
+            published_at: db_album.published_at,
+            tagged_users,
+        })
+    }
+
+    Ok(albums)
+}
+
+pub(super) async fn get(
+    Authorize(username): Authorize,
+    Query(filter): Query<AlbumFilters>,
+    Extension(state): Extension<Arc<AppState>>,
+) -> Result<Json<Vec<AlbumMetadata>>, Error> {
+    state
+        .db
+        .call(move |conn| Ok(Json(get_albums(username, filter, conn)?)))
         .await
 }
 
@@ -98,12 +105,9 @@ mod test {
         let users = state
             .db
             .call(move |conn| {
-                let users = vec![
-                    insert_user("test", conn).unwrap(),
-                    insert_user("test2", conn).unwrap(),
-                ];
+                let users = vec![insert_user("test", conn), insert_user("test2", conn)];
                 let user = users[0].clone();
-                let image = insert_image(&user, conn).unwrap();
+                let image = insert_image(&user, conn);
                 let _ = insert_album(
                     InsertAlbum {
                         cover_key: &image,
@@ -113,8 +117,7 @@ mod test {
                         ..Default::default()
                     },
                     conn,
-                )
-                .unwrap();
+                );
 
                 users
             })

--- a/backend/src/api/album/get_by_key.rs
+++ b/backend/src/api/album/get_by_key.rs
@@ -42,11 +42,11 @@ mod test {
         let (album, images) = state
             .db
             .call(move |conn| {
-                let user = insert_user("test", conn).unwrap();
+                let user = insert_user("test", conn);
 
                 let mut images = Vec::new();
                 for _ in comment_count {
-                    images.push(insert_image(&user, conn).unwrap());
+                    images.push(insert_image(&user, conn));
                 }
 
                 let album = insert_album(
@@ -57,12 +57,11 @@ mod test {
                         ..Default::default()
                     },
                     conn,
-                )
-                .unwrap();
+                );
 
                 for (count, img) in comment_count.iter().zip(images.iter()) {
                     for _ in 0..*count {
-                        insert_comment(&user, &img, &album, "text", conn).unwrap();
+                        insert_comment(&user, &img, &album, "text", conn);
                     }
                 }
 
@@ -86,12 +85,9 @@ mod test {
         let (album, users) = state
             .db
             .call(move |conn| {
-                let users = vec![
-                    insert_user("test", conn).unwrap(),
-                    insert_user("test2", conn).unwrap(),
-                ];
+                let users = vec![insert_user("test", conn), insert_user("test2", conn)];
                 let user = users[0].clone();
-                let image = insert_image(&user, conn).unwrap();
+                let image = insert_image(&user, conn);
                 let album = insert_album(
                     InsertAlbum {
                         cover_key: &image,
@@ -101,8 +97,7 @@ mod test {
                         ..Default::default()
                     },
                     conn,
-                )
-                .unwrap();
+                );
 
                 (album, users)
             })

--- a/backend/src/api/album/get_by_share_token.rs
+++ b/backend/src/api/album/get_by_share_token.rs
@@ -24,7 +24,7 @@ pub(super) struct AlbumResponse {
     author: String,
     draft: bool,
     timeframe: Timeframe,
-    created_at: u64,
+    published_at: u64,
     images: Vec<Image>,
     tagged_users: Vec<String>,
 }
@@ -47,7 +47,7 @@ pub(super) async fn get(
                     a.draft, \
                     a.timeframe_from, \
                     a.timeframe_to, \
-                    a.created_at \
+                    a.published_at \
                 FROM albums a \
                 WHERE a.key=?1",
                     params![album_key],
@@ -111,7 +111,7 @@ pub(super) async fn get(
                         from: db_album.timeframe_from,
                         to: db_album.timeframe_to,
                     },
-                    created_at: db_album.created_at,
+                    published_at: db_album.published_at,
                     images,
                     tagged_users,
                 }))
@@ -136,8 +136,8 @@ mod test {
         let expected_album_key = state
             .db
             .call(move |conn| {
-                let user = insert_user("test", conn).unwrap();
-                let image = insert_image(&user, conn).unwrap();
+                let user = insert_user("test", conn);
+                let image = insert_image(&user, conn);
                 let album_key = insert_album(
                     InsertAlbum {
                         cover_key: &image,
@@ -145,8 +145,7 @@ mod test {
                         ..Default::default()
                     },
                     conn,
-                )
-                .unwrap();
+                );
 
                 insert_share_token(
                     InsertShareToken {
@@ -155,8 +154,7 @@ mod test {
                         ..Default::default()
                     },
                     conn,
-                )
-                .unwrap();
+                );
 
                 album_key
             })

--- a/backend/src/api/album/get_filters.rs
+++ b/backend/src/api/album/get_filters.rs
@@ -120,8 +120,8 @@ mod test {
         let user = state
             .db
             .call(move |conn| {
-                let user = insert_user("test", conn).unwrap();
-                let image = insert_image(&user, conn).unwrap();
+                let user = insert_user("test", conn);
+                let image = insert_image(&user, conn);
                 let _ = insert_album(
                     InsertAlbum {
                         cover_key: &image,
@@ -131,8 +131,7 @@ mod test {
                         ..Default::default()
                     },
                     conn,
-                )
-                .unwrap();
+                );
 
                 let _ = insert_album(
                     InsertAlbum {
@@ -142,8 +141,7 @@ mod test {
                         ..Default::default()
                     },
                     conn,
-                )
-                .unwrap();
+                );
 
                 user
             })
@@ -181,8 +179,8 @@ mod test {
         let user = state
             .db
             .call(move |conn| {
-                let user = insert_user("test", conn).unwrap();
-                let image = insert_image(&user, conn).unwrap();
+                let user = insert_user("test", conn);
+                let image = insert_image(&user, conn);
                 let _ = insert_album(
                     InsertAlbum {
                         cover_key: &image,
@@ -192,8 +190,7 @@ mod test {
                         ..Default::default()
                     },
                     conn,
-                )
-                .unwrap();
+                );
 
                 let _ = insert_album(
                     InsertAlbum {
@@ -203,8 +200,7 @@ mod test {
                         ..Default::default()
                     },
                     conn,
-                )
-                .unwrap();
+                );
 
                 user
             })

--- a/backend/src/api/comment.rs
+++ b/backend/src/api/comment.rs
@@ -4,6 +4,10 @@ use axum::{
     Router,
 };
 use rusqlite::{params, Connection};
+use serde::{Deserialize, Serialize};
+use serde_rusqlite::from_row;
+
+use crate::api::error::Error;
 
 mod create_comment;
 mod delete_comment;
@@ -21,15 +25,15 @@ pub fn public_api_route() -> Router {
     Router::new().route("/:album/:image/:token", get(get_shared_comments::get))
 }
 
-#[derive(Eq, PartialEq, Debug, serde::Serialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(Eq, PartialEq, Debug, Serialize, Deserialize)]
+#[serde(rename_all(serialize = "camelCase"))]
 pub struct Comment {
-    id: i64,
-    author: String,
-    image_key: String,
-    album_key: String,
-    created_at: u64,
-    text: String,
+    pub id: i64,
+    pub author: String,
+    pub image_key: String,
+    pub album_key: String,
+    pub created_at: u64,
+    pub text: String,
 }
 
 pub fn insert_comment(
@@ -41,7 +45,8 @@ pub fn insert_comment(
     conn: &Connection,
 ) -> anyhow::Result<Comment> {
     conn.execute(
-        "INSERT INTO comments (author, image_key, album_key, created_at, text) VALUES (?1, ?2, ?3, ?4, ?5)",
+        "INSERT INTO comments (author, image_key, album_key, created_at, text) \
+        VALUES (?1, ?2, ?3, ?4, ?5)",
         params![&author, &image_key, &album_key, created_at, text],
     )
     .context("Failed to insert comment")?;
@@ -81,4 +86,22 @@ pub fn get_comment(id: i64, conn: &Connection) -> anyhow::Result<Option<Comment>
     let comment = result.context("Failed to get comment")?;
 
     Ok(Some(comment))
+}
+
+pub fn get_all(conn: &Connection) -> Result<Vec<Comment>, Error> {
+    let mut stmt = conn
+        .prepare(
+            "SELECT c.id, c.text, c.author, c.image_key, c.album_key, c.created_at \
+                FROM comments c \
+                INNER JOIN images i ON c.image_key = i.key",
+        )
+        .context("Failed to prepare statement for comment query")?;
+
+    let comments = stmt
+        .query_map(params![], |row| Ok(from_row(row).unwrap()))
+        .context("Failed to query comments")?
+        .collect::<Result<Vec<_>, _>>()
+        .context("Failed to collect comments")?;
+
+    Ok(comments)
 }

--- a/backend/src/api/comment/create_comment.rs
+++ b/backend/src/api/comment/create_comment.rs
@@ -92,8 +92,8 @@ mod test {
         let (user, album) = state
             .db
             .call(move |conn| {
-                let user = insert_user("test", conn).unwrap();
-                let image = insert_image(&user, conn).unwrap();
+                let user = insert_user("test", conn);
+                let image = insert_image(&user, conn);
                 let album = insert_album(
                     InsertAlbum {
                         cover_key: &image,
@@ -102,8 +102,7 @@ mod test {
                         ..Default::default()
                     },
                     conn,
-                )
-                .unwrap();
+                );
 
                 (user, album)
             })
@@ -130,8 +129,8 @@ mod test {
         let (user, image, album) = state
             .db
             .call(move |conn| {
-                let user = insert_user("test", conn).unwrap();
-                let image = insert_image(&user, conn).unwrap();
+                let user = insert_user("test", conn);
+                let image = insert_image(&user, conn);
                 let album = insert_album(
                     InsertAlbum {
                         cover_key: &image,
@@ -140,8 +139,7 @@ mod test {
                         ..Default::default()
                     },
                     conn,
-                )
-                .unwrap();
+                );
 
                 (user, image, album)
             })
@@ -177,11 +175,11 @@ mod test {
             .db
             .call(move |conn| {
                 for (name, content) in aliases {
-                    insert_alias(name, content, conn).unwrap();
+                    insert_alias(name, content, conn);
                 }
 
-                let user = insert_user("test", conn).unwrap();
-                let image = insert_image(&user, conn).unwrap();
+                let user = insert_user("test", conn);
+                let image = insert_image(&user, conn);
                 let album = insert_album(
                     InsertAlbum {
                         cover_key: &image,
@@ -190,8 +188,7 @@ mod test {
                         ..Default::default()
                     },
                     conn,
-                )
-                .unwrap();
+                );
 
                 (user, image, album)
             })

--- a/backend/src/api/comment/delete_comment.rs
+++ b/backend/src/api/comment/delete_comment.rs
@@ -56,8 +56,8 @@ mod test {
         let user = state
             .db
             .call(move |conn| {
-                let user = insert_user("test", conn).unwrap();
-                let image = insert_image(&user, conn).unwrap();
+                let user = insert_user("test", conn);
+                let image = insert_image(&user, conn);
                 let album = insert_album(
                     InsertAlbum {
                         cover_key: &image,
@@ -66,9 +66,8 @@ mod test {
                         ..Default::default()
                     },
                     conn,
-                )
-                .unwrap();
-                let _ = insert_comment(&user, &image, &album, "text", conn).unwrap();
+                );
+                let _ = insert_comment(&user, &image, &album, "text", conn);
 
                 user
             })
@@ -86,8 +85,8 @@ mod test {
         let (user, comment) = state
             .db
             .call(move |conn| {
-                let user = insert_user("test", conn).unwrap();
-                let image = insert_image(&user, conn).unwrap();
+                let user = insert_user("test", conn);
+                let image = insert_image(&user, conn);
                 let album = insert_album(
                     InsertAlbum {
                         cover_key: &image,
@@ -96,11 +95,9 @@ mod test {
                         ..Default::default()
                     },
                     conn,
-                )
-                .unwrap();
-                let Comment { id, .. } =
-                    insert_comment(&user, &image, &album, "text", conn).unwrap();
-                let user2 = insert_user("test2", conn).unwrap();
+                );
+                let Comment { id, .. } = insert_comment(&user, &image, &album, "text", conn);
+                let user2 = insert_user("test2", conn);
 
                 (user2, id)
             })
@@ -118,8 +115,8 @@ mod test {
         let (user, comment) = state
             .db
             .call(move |conn| {
-                let user = insert_user("test", conn).unwrap();
-                let image = insert_image(&user, conn).unwrap();
+                let user = insert_user("test", conn);
+                let image = insert_image(&user, conn);
                 let album = insert_album(
                     InsertAlbum {
                         cover_key: &image,
@@ -128,9 +125,8 @@ mod test {
                         ..Default::default()
                     },
                     conn,
-                )
-                .unwrap();
-                let comment = insert_comment(&user, &image, &album, "text", conn).unwrap();
+                );
+                let comment = insert_comment(&user, &image, &album, "text", conn);
 
                 (user, comment)
             })
@@ -150,8 +146,8 @@ mod test {
         let (user, comment) = state
             .db
             .call(move |conn| {
-                let user = insert_user("test", conn).unwrap();
-                let image = insert_image(&user, conn).unwrap();
+                let user = insert_user("test", conn);
+                let image = insert_image(&user, conn);
                 let album = insert_album(
                     InsertAlbum {
                         cover_key: &image,
@@ -160,10 +156,9 @@ mod test {
                         ..Default::default()
                     },
                     conn,
-                )
-                .unwrap();
-                let user2 = insert_user("test2", conn).unwrap();
-                let comment = insert_comment(&user2, &image, &album, "text", conn).unwrap();
+                );
+                let user2 = insert_user("test2", conn);
+                let comment = insert_comment(&user2, &image, &album, "text", conn);
 
                 (user, comment)
             })

--- a/backend/src/api/comment/get_all_comments.rs
+++ b/backend/src/api/comment/get_all_comments.rs
@@ -89,8 +89,8 @@ mod test {
         let (album, image) = state
             .db
             .call(move |conn| {
-                let user = insert_user("test", conn).unwrap();
-                let image = insert_image(&user, conn).unwrap();
+                let user = insert_user("test", conn);
+                let image = insert_image(&user, conn);
                 let album = insert_album(
                     InsertAlbum {
                         cover_key: &image,
@@ -99,10 +99,9 @@ mod test {
                         ..Default::default()
                     },
                     conn,
-                )
-                .unwrap();
-                insert_comment(&user, &image, &album, "foo", conn).unwrap();
-                insert_comment(&user, &image, &album, "bar", conn).unwrap();
+                );
+                insert_comment(&user, &image, &album, "foo", conn);
+                insert_comment(&user, &image, &album, "bar", conn);
 
                 (album, image)
             })
@@ -123,8 +122,8 @@ mod test {
         let (album, image) = state
             .db
             .call(move |conn| {
-                let user = insert_user("test", conn).unwrap();
-                let key = insert_image(&user, conn).unwrap();
+                let user = insert_user("test", conn);
+                let key = insert_image(&user, conn);
                 let album = insert_album(
                     InsertAlbum {
                         cover_key: &key,
@@ -133,11 +132,10 @@ mod test {
                         ..Default::default()
                     },
                     conn,
-                )
-                .unwrap();
-                insert_comment(&user, &key, &album, "foo", conn).unwrap();
-                insert_comment(&user, &key, &album, "bar", conn).unwrap();
-                let key2 = insert_image(&user, conn).unwrap();
+                );
+                insert_comment(&user, &key, &album, "foo", conn);
+                insert_comment(&user, &key, &album, "bar", conn);
+                let key2 = insert_image(&user, conn);
                 let album2 = insert_album(
                     InsertAlbum {
                         cover_key: &key2,
@@ -146,9 +144,8 @@ mod test {
                         ..Default::default()
                     },
                     conn,
-                )
-                .unwrap();
-                insert_comment(&user, &key2, &album2, "quux", conn).unwrap();
+                );
+                insert_comment(&user, &key2, &album2, "quux", conn);
 
                 (album, key)
             })

--- a/backend/src/api/comment/get_shared_comments.rs
+++ b/backend/src/api/comment/get_shared_comments.rs
@@ -89,8 +89,8 @@ mod test {
         let (album, image) = state
             .db
             .call(move |conn| {
-                let user = insert_user("test", conn).unwrap();
-                let image = insert_image(&user, conn).unwrap();
+                let user = insert_user("test", conn);
+                let image = insert_image(&user, conn);
                 let album = insert_album(
                     InsertAlbum {
                         cover_key: &image,
@@ -99,10 +99,9 @@ mod test {
                         ..Default::default()
                     },
                     conn,
-                )
-                .unwrap();
-                insert_comment(&user, &image, &album, "foo", conn).unwrap();
-                insert_comment(&user, &image, &album, "bar", conn).unwrap();
+                );
+                insert_comment(&user, &image, &album, "foo", conn);
+                insert_comment(&user, &image, &album, "bar", conn);
 
                 (album, image)
             })
@@ -128,8 +127,8 @@ mod test {
         let (album, image) = state
             .db
             .call(move |conn| {
-                let user = insert_user("test", conn).unwrap();
-                let key = insert_image(&user, conn).unwrap();
+                let user = insert_user("test", conn);
+                let key = insert_image(&user, conn);
                 let album = insert_album(
                     InsertAlbum {
                         cover_key: &key,
@@ -138,11 +137,10 @@ mod test {
                         ..Default::default()
                     },
                     conn,
-                )
-                .unwrap();
-                insert_comment(&user, &key, &album, "foo", conn).unwrap();
-                insert_comment(&user, &key, &album, "bar", conn).unwrap();
-                let key2 = insert_image(&user, conn).unwrap();
+                );
+                insert_comment(&user, &key, &album, "foo", conn);
+                insert_comment(&user, &key, &album, "bar", conn);
+                let key2 = insert_image(&user, conn);
                 let album2 = insert_album(
                     InsertAlbum {
                         cover_key: &key2,
@@ -151,9 +149,8 @@ mod test {
                         ..Default::default()
                     },
                     conn,
-                )
-                .unwrap();
-                insert_comment(&user, &key2, &album2, "quux", conn).unwrap();
+                );
+                insert_comment(&user, &key2, &album2, "quux", conn);
 
                 (album, key)
             })

--- a/backend/src/api/image.rs
+++ b/backend/src/api/image.rs
@@ -29,7 +29,7 @@ pub fn api_route() -> Router {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct ImageMetadata {
+pub struct ImageMetadata {
     file_name: String,
     size_bytes: u64,
     taken_at: Option<i64>,
@@ -51,11 +51,12 @@ pub(super) fn non_empty_location<'de, D: Deserializer<'de>>(
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct Image {
+pub struct Image {
     pub key: String,
     pub description: Option<String>,
     pub uploader: String,
     pub uploaded_at: u64,
+    pub published_at: Option<u64>,
 
     #[serde(flatten)]
     pub metadata: ImageMetadata,
@@ -75,6 +76,7 @@ impl Image {
             description: db_metadata.description,
             uploader: db_metadata.uploader,
             uploaded_at: db_metadata.uploaded_at,
+            published_at: db_metadata.published_at,
             metadata: db_metadata.metadata.into(),
         }
     }
@@ -125,6 +127,8 @@ pub struct DbImage {
     pub description: Option<String>,
     pub uploader: String,
     pub uploaded_at: u64,
+    #[serde(skip_serializing)]
+    pub published_at: Option<u64>,
 
     #[serde(flatten)]
     pub metadata: DbImageMetadata,

--- a/backend/src/api/image/get_all.rs
+++ b/backend/src/api/image/get_all.rs
@@ -86,12 +86,12 @@ mod test {
         let (bob, alice, expected_bob_images) = state
             .db
             .call(move |conn| {
-                let bob = insert_user("bob", conn).unwrap();
-                let alice = insert_user("alice", conn).unwrap();
+                let bob = insert_user("bob", conn);
+                let alice = insert_user("alice", conn);
                 let images = vec![
-                    insert_image(&bob, conn).unwrap(),
-                    insert_image(&bob, conn).unwrap(),
-                    insert_image(&bob, conn).unwrap(),
+                    insert_image(&bob, conn),
+                    insert_image(&bob, conn),
+                    insert_image(&bob, conn),
                 ];
 
                 (bob, alice, images)
@@ -118,12 +118,12 @@ mod test {
         let (user, expected_images) = state
             .db
             .call(move |conn| {
-                let user = insert_user("test", conn).unwrap();
+                let user = insert_user("test", conn);
                 let images = vec![
-                    insert_image(&user, conn).unwrap(),
-                    insert_image(&user, conn).unwrap(),
-                    insert_image(&user, conn).unwrap(),
-                    insert_image(&user, conn).unwrap(),
+                    insert_image(&user, conn),
+                    insert_image(&user, conn),
+                    insert_image(&user, conn),
+                    insert_image(&user, conn),
                 ];
 
                 (user, images)
@@ -146,12 +146,12 @@ mod test {
         let (user, expected_images, expected_album) = state
             .db
             .call(move |conn| {
-                let user = insert_user("test", conn).unwrap();
+                let user = insert_user("test", conn);
                 let images = vec![
-                    insert_image(&user, conn).unwrap(),
-                    insert_image(&user, conn).unwrap(),
-                    insert_image(&user, conn).unwrap(),
-                    insert_image(&user, conn).unwrap(),
+                    insert_image(&user, conn),
+                    insert_image(&user, conn),
+                    insert_image(&user, conn),
+                    insert_image(&user, conn),
                 ];
                 let album = insert_album(
                     InsertAlbum {
@@ -161,8 +161,7 @@ mod test {
                         ..Default::default()
                     },
                     conn,
-                )
-                .unwrap();
+                );
 
                 (user, images, album)
             })

--- a/backend/src/api/image/update_metadata.rs
+++ b/backend/src/api/image/update_metadata.rs
@@ -220,8 +220,8 @@ mod test {
         let (user, image) = state
             .db
             .call(move |conn| {
-                let user = insert_user("test", conn).unwrap();
-                let image = insert_image(&user, conn).unwrap();
+                let user = insert_user("test", conn);
+                let image = insert_image(&user, conn);
 
                 (user, image)
             })

--- a/backend/src/api/image/upload.rs
+++ b/backend/src/api/image/upload.rs
@@ -60,6 +60,7 @@ pub(super) async fn post(
         description: None,
         uploader,
         uploaded_at,
+        published_at: None,
         metadata: DbImageMetadata {
             file_name,
             size_bytes,

--- a/backend/src/util.rs
+++ b/backend/src/util.rs
@@ -47,8 +47,8 @@ pub mod test {
     };
     use rusqlite_migration::Migrations;
 
-    pub async fn setup_database() -> anyhow::Result<tokio_rusqlite::Connection> {
-        let db = tokio_rusqlite::Connection::open_in_memory().await?;
+    pub async fn setup_database() -> tokio_rusqlite::Connection {
+        let db = tokio_rusqlite::Connection::open_in_memory().await.unwrap();
 
         let migrations = Migrations::new(crate::MIGRATIONS.to_vec());
 
@@ -59,31 +59,27 @@ pub mod test {
 
             Ok::<_, anyhow::Error>(())
         })
-        .await?;
+        .await
+        .unwrap();
 
-        Ok(db)
+        db
     }
 
-    pub fn insert_user(name: &str, conn: &rusqlite::Connection) -> anyhow::Result<String> {
-        user::insert(name, "", 0, conn)?;
+    pub fn insert_user(name: &str, conn: &rusqlite::Connection) -> String {
+        user::insert(name, "", 0, conn).unwrap();
 
-        Ok(name.to_string())
+        name.to_string()
     }
 
-    pub fn insert_alias(
-        name: &str,
-        content: &str,
-        conn: &rusqlite::Connection,
-    ) -> anyhow::Result<()> {
+    pub fn insert_alias(name: &str, content: &str, conn: &rusqlite::Connection) {
         conn.execute(
             "INSERT INTO aliases (name, content) VALUES (?1, ?2)",
             rusqlite::params![name, content],
-        )?;
-
-        Ok(())
+        )
+        .unwrap();
     }
 
-    pub fn insert_image(uploader: &str, conn: &rusqlite::Connection) -> anyhow::Result<String> {
+    pub fn insert_image(uploader: &str, conn: &rusqlite::Connection) -> String {
         let key = blob_uuid::random_blob();
 
         let i = image::DbImage {
@@ -94,9 +90,9 @@ pub mod test {
             ..Default::default()
         };
 
-        image::insert(&i, conn)?;
+        image::insert(&i, conn).unwrap();
 
-        Ok(key)
+        key
     }
 
     pub fn insert_comment(
@@ -105,7 +101,7 @@ pub mod test {
         album_key: &str,
         text: &str,
         conn: &rusqlite::Connection,
-    ) -> anyhow::Result<comment::Comment> {
+    ) -> comment::Comment {
         comment::insert_comment(
             author.into(),
             text.into(),
@@ -114,44 +110,34 @@ pub mod test {
             0,
             conn,
         )
+        .unwrap()
     }
 
-    pub fn insert_album(album: InsertAlbum, conn: &rusqlite::Connection) -> anyhow::Result<String> {
-        fn insert_album<'a>(
-            key: &'a str,
-            mut album: InsertAlbum<'a>,
-            conn: &rusqlite::Connection,
-        ) -> anyhow::Result<()> {
+    pub fn insert_album(album: InsertAlbum, conn: &rusqlite::Connection) -> String {
+        fn insert_album<'a>(key: &'a str, mut album: InsertAlbum<'a>, conn: &rusqlite::Connection) {
             album.key = &key;
-            album::insert_album(album, conn)?;
-
-            Ok(())
+            album::insert_album(album, conn).unwrap();
         }
 
         let key = blob_uuid::random_blob();
-        insert_album(&key, album, conn)?;
+        insert_album(&key, album, conn);
 
-        Ok(key)
+        key
     }
 
-    pub fn insert_share_token(
-        rows: InsertShareToken,
-        conn: &rusqlite::Connection,
-    ) -> anyhow::Result<String> {
+    pub fn insert_share_token(rows: InsertShareToken, conn: &rusqlite::Connection) -> String {
         fn insert_token<'a>(
             token: &'a str,
             mut rows: InsertShareToken<'a>,
             conn: &rusqlite::Connection,
-        ) -> anyhow::Result<()> {
+        ) {
             rows.share_token = &token;
-            album::insert_share_token(rows, conn)?;
-
-            Ok(())
+            album::insert_share_token(rows, conn).unwrap();
         }
 
         let token = blob_uuid::random_blob();
-        insert_token(&token, rows, conn)?;
+        insert_token(&token, rows, conn);
 
-        Ok(token)
+        token
     }
 }


### PR DESCRIPTION
The created_at timestamp on albums got renamed to published_at and gets
updated when draft gets changed to false now. Images also have publish
dates now which are attached to each of the album associations.

The amount of activitities that are returned by this endpoint will
probably have to to be limited in the future and comments may still need
additional metadata to simplify things for the front end.