### PR TITLE
Disable setting published albums to draft

### DIFF
--- a/backend/src/api/error.rs
+++ b/backend/src/api/error.rs
@@ -46,6 +46,9 @@ pub enum Error {
     #[error("One of the album or image keys is not valid")]
     InvalidKey,
 
+    #[error("Album was already published, can't set back to draft")]
+    AlreadyPublished,
+
     #[error("{field} should not be longer than {maximum_length} characters")]
     TooManyCharacters {
         field: &'static str,
@@ -83,6 +86,7 @@ impl IntoResponse for Error {
             }
             Error::InvalidCoverKey
             | Error::InvalidKey
+            | Error::AlreadyPublished
             | Error::NoImage
             | Error::ImageError(_)
             | Error::InvalidTimeframe

--- a/backend/src/cli.rs
+++ b/backend/src/cli.rs
@@ -2,21 +2,21 @@ use anyhow::bail;
 use argh::FromArgs;
 use rusqlite::Connection;
 
-#[derive(FromArgs, PartialEq, Debug)]
+#[derive(FromArgs, PartialEq, Eq, Debug)]
 /// Top-level command.
 pub struct Args {
     #[argh(subcommand)]
     pub subcommand: Option<SubCommands>,
 }
 
-#[derive(FromArgs, PartialEq, Debug)]
+#[derive(FromArgs, PartialEq, Eq, Debug)]
 #[argh(subcommand)]
 pub enum SubCommands {
     AddUser(AddUserArgs),
     EditUser(EditUserArgs),
 }
 
-#[derive(FromArgs, PartialEq, Debug)]
+#[derive(FromArgs, PartialEq, Eq, Debug)]
 /// create account.
 #[argh(subcommand, name = "add")]
 pub struct AddUserArgs {
@@ -29,7 +29,7 @@ pub struct AddUserArgs {
     pub password: Option<String>,
 }
 
-#[derive(FromArgs, PartialEq, Debug)]
+#[derive(FromArgs, PartialEq, Eq, Debug)]
 /// edit account.
 #[argh(subcommand, name = "edit")]
 pub struct EditUserArgs {


### PR DESCRIPTION
A draft should be a version of the album that isn't ready to be released, letting users set an already published album back to draft seems counterintuitive to me. Additionally the it creates new questions around ordering and the activity log while not providing a lot of value.

Additionally requests that try to unset the draft status are ignored to not update the publish date.

Resolves #130.