### PR TITLE
Add albumKeys field to images on the activity endpoint

### DIFF
--- a/backend/src/api/image.rs
+++ b/backend/src/api/image.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use serde_rusqlite::{from_row, to_params_named};
 
 mod delete_image;
-mod get_all;
+pub mod get_all;
 mod get_by_key;
 mod orientation;
 mod update_metadata;

--- a/backend/src/api/image/get_all.rs
+++ b/backend/src/api/image/get_all.rs
@@ -16,7 +16,7 @@ use rusqlite::params;
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub(super) struct AllImagesImage {
+pub struct AllImagesImage {
     pub album_keys: Vec<String>,
 
     #[serde(flatten)]
@@ -55,7 +55,7 @@ pub(super) async fn get(
         .await
 }
 
-fn get_albums_containing_image(
+pub fn get_albums_containing_image(
     key: &str,
     conn: &rusqlite::Connection,
 ) -> anyhow::Result<Vec<String>> {


### PR DESCRIPTION
Also adds a test to ensure that "private" images are not shown in the activity log.

Resolves #132.